### PR TITLE
Plan 3: HTMX two-panel UI with dark theme, SSE narrative feed, privacy dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,157 +1,159 @@
-Update 4/6:
+# AaplaManus
 
-![image](https://github.com/user-attachments/assets/4b4ce2fe-a95f-48b0-95f9-2e60392afcff)
-Actual Manus Beta in play
---------------------------------------------------------------------------------------------------------------
+Local-first multi-agent AI system built on [Ollama](https://ollama.com). Run AI agents on your own hardware — no API keys, no monthly bill, no data leaving the machine.
 
-# AAPLA Manus forked from OpenManus
-Autonomous Agent Platform for Learning and Action
+> **Aapla Manus** is Marathi for "our person." The agent runs on your machine, answering to you.
 
-[Official Website](https://openmanus.github.io/)
+Forked from [OpenManus](https://github.com/mannaandpoem/OpenManus) and rebuilt for local-first operation.
 
-Manus is incredible, but OpenManus can achieve any idea without an *Invite Code* 🛫!
+---
 
-For Anthropic's Claude, you need to use their exact model identifiers. The correct model name format for Claude 3.5 Sonnet would be:
-**Copyclaude-3-5-sonnet-20240620
-**
+## What it does
 
+AaplaManus gives you a set of agents — browser, code, research, file — that work together to complete tasks. Every run stays local by default. Cloud is an opt-in escape hatch, not the default.
 
-## Project Demo
+**Three pillars:**
+1. Agent tasks as the core — browse, code, research, read files
+2. Cost savings as the hook — every session shows dollars saved vs GPT-4o
+3. Smart routing — local by default, cloud only when you approve
 
-<video src="https://private-user-images.githubusercontent.com/61239030/420168772-6dcfd0d2-9142-45d9-b74e-d10aa75073c6.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDEzMTgwNTksIm5iZiI6MTc0MTMxNzc1OSwicGF0aCI6Ii82MTIzOTAzMC80MjAxNjg3NzItNmRjZmQwZDItOTE0Mi00NWQ5LWI3NGUtZDEwYWE3NTA3M2M2Lm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTAzMDclMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwMzA3VDAzMjIzOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTdiZjFkNjlmYWNjMmEzOTliM2Y3M2VlYjgyNDRlZDJmOWE3NWZhZjE1MzhiZWY4YmQ3NjdkNTYwYTU5ZDA2MzYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.UuHQCgWYkh0OQq9qsUWqGsUbhG3i9jcZDAMeHjLt5T4" data-canonical-src="https://private-user-images.githubusercontent.com/61239030/420168772-6dcfd0d2-9142-45d9-b74e-d10aa75073c6.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDEzMTgwNTksIm5iZiI6MTc0MTMxNzc1OSwicGF0aCI6Ii82MTIzOTAzMC80MjAxNjg3NzItNmRjZmQwZDItOTE0Mi00NWQ5LWI3NGUtZDEwYWE3NTA3M2M2Lm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTAzMDclMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwMzA3VDAzMjIzOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTdiZjFkNjlmYWNjMmEzOTliM2Y3M2VlYjgyNDRlZDJmOWE3NWZhZjE1MzhiZWY4YmQ3NjdkNTYwYTU5ZDA2MzYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.UuHQCgWYkh0OQq9qsUWqGsUbhG3i9jcZDAMeHjLt5T4" controls="controls" muted="muted" class="d-block rounded-bottom-2 border-top width-fit" style="max-height:640px; min-height: 200px"></video>
+---
 
-## Installation
+## Architecture
 
-We provide two installation methods. Method 2 (using uv) is recommended for faster installation and better dependency management.
-
-### Method 1: Using conda
-
-1. Create a new conda environment:
-
-```bash
-conda create -n open_manus python=3.12
-conda activate open_manus
+```
+User (Web UI)
+    |
+FastAPI + SSE (app.py)
+    |
+Orchestrator  →  SmartRouter (keyword classifier, no LLM call)
+    |
+[File Agent] [Browser Agent] [Code Agent] [Research Agent]
+    |
+Ollama (local LLM runtime, OpenAI-compatible API)
+    |
+Cost Service (SQLite, tracks tokens and savings per session)
 ```
 
-2. Clone the repository:
+**Model assignments:**
+
+| Label | Model | Used for |
+|---|---|---|
+| Fast Local | qwen2.5:7b | Routing, simple tasks |
+| Smart Local | llama3.2:latest | Research, synthesis |
+| Code Expert | qwen2.5-coder:14b | Code generation |
+
+---
+
+## Agents
+
+- **FileAgent** — reads files from the workspace, summarizes contents
+- **BrowserAgent** — searches the web, fetches and extracts page text
+- **CodeAgent** — writes and executes Python, retries up to 3x on failure
+- **ResearchAgent** — synthesizes outputs from other agents into a final answer
+- **Orchestrator** — routes the task, chains agents, returns the final result
+
+---
+
+## Getting started
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose
+- [Ollama](https://ollama.com) (or let Docker pull it automatically)
+
+### Run with Docker Compose
 
 ```bash
-git clone https://github.com/mannaandpoem/OpenManus.git
-cd OpenManus
+git clone https://github.com/swapniltamse/AaplaManus.git
+cd AaplaManus
+cp config/config.example.toml config/config.toml
+docker compose up
 ```
 
-3. Install dependencies:
+App runs at `http://localhost:3000`.
+
+Ollama starts automatically inside Docker. On first run, pull the models you want:
 
 ```bash
-pip install -r requirements.txt
+docker exec -it aaplamanus-ollama-1 ollama pull llama3.2
+docker exec -it aaplamanus-ollama-1 ollama pull qwen2.5:7b
+docker exec -it aaplamanus-ollama-1 ollama pull qwen2.5-coder:14b
 ```
 
-### Method 2: Using uv (Recommended)
-
-1. Install uv (A fast Python package installer and resolver):
+### Run locally (without Docker)
 
 ```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
+git clone https://github.com/swapniltamse/AaplaManus.git
+cd AaplaManus
+cp config/config.example.toml config/config.toml
 
-2. Clone the repository:
-
-```bash
-git clone https://github.com/mannaandpoem/OpenManus.git
-cd OpenManus
-```
-
-3. Create a new virtual environment and activate it:
-
-```bash
-uv venv
-source .venv/bin/activate  # On Unix/macOS
-# Or on Windows:
-# .venv\Scripts\activate
-```
-
-4. Install dependencies:
-
-```bash
+uv venv && source .venv/bin/activate  # or .venv\Scripts\activate on Windows
 uv pip install -r requirements.txt
+
+uvicorn app:app --host 0.0.0.0 --port 3000
 ```
+
+Requires Ollama running at `http://localhost:11434` (default).
+
+---
 
 ## Configuration
 
-OpenManus requires configuration for the LLM APIs it uses. Follow these steps to set up your configuration:
-
-1. Create a `config.toml` file in the `config` directory (you can copy from the example):
-
-```bash
-cp config/config.example.toml config/config.toml
-```
-
-2. Edit `config/config.toml` to add your API keys and customize settings:
+`config/config.toml` (copy from `config.example.toml`):
 
 ```toml
-# Global LLM configuration
 [llm]
-model = "gpt-4o"
-base_url = "https://api.openai.com/v1"
-api_key = "sk-..."  # Replace with your actual API key
+model = "llama3.2:latest"
+base_url = "http://localhost:11434/v1"
+api_key = "ollama"
 max_tokens = 4096
 temperature = 0.0
-
-# Optional configuration for specific LLM models
-[llm.vision]
-model = "gpt-4o"
-base_url = "https://api.openai.com/v1"
-api_key = "sk-..."  # Replace with your actual API key
 ```
 
-## Quick Start
-
-One line for run OpenManus:
+Set `OLLAMA_HOST` env var to override the Ollama URL (useful in Docker):
 
 ```bash
-python main.py
+OLLAMA_HOST=http://ollama:11434
 ```
 
-Then input your idea via terminal!
+---
 
-For unstable version, you also can run:
+## Cost dashboard
+
+Every agent call is tracked. Check your session savings:
+
+```
+GET /dashboard/stats
+```
+
+Returns total tokens used, estimated cost, and savings vs GPT-4o rates.
+
+---
+
+## Tests
 
 ```bash
-python run_flow.py
+.venv/Scripts/python.exe -m pytest tests/ -v   # Windows
+python -m pytest tests/ -v                      # Linux/Mac
 ```
 
-## How to contribute
+42 tests across types, agents, orchestrator, and integration.
 
-We welcome any friendly suggestions and helpful contributions! Just create issues or submit pull requests.
+---
 
-Or contact @mannaandpoem via 📧email: mannaandpoem@gmail.com
+## Roadmap
 
-## Community Group
-Join our networking group on Feishu and share your experience with other developers!
+- [x] Plan 1: Ollama integration, Cost Service, Smart Router, Docker
+- [x] Plan 2: File, Browser, Code, Research agents + Orchestrator
+- [ ] Plan 3: UI redesign — TBD
+- [ ] Plan 4: Setup flow and first-run experience — TBD
+- [ ] Plan 5: Cloud approval dialog and opt-in routing — TBD
+- [ ] Plan 6: Desktop app (Tauri) — TBD
 
-<div align="center" style="display: flex; gap: 20px;">
-    <img src="assets/community_group.jpg" alt="OpenManus 交流群" width="300" />
-</div>
+---
 
-## Star History
+## Acknowledgements
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mannaandpoem/OpenManus&type=Date)](https://star-history.com/#mannaandpoem/OpenManus&Date)
-
-## Acknowledgement
-
-Thanks to [anthropic-computer-use](https://github.com/anthropics/anthropic-quickstarts/tree/main/computer-use-demo)
-and [browser-use](https://github.com/browser-use/browser-use) for providing basic support for this project!
-
-OpenManus is built by contributors from MetaGPT. Huge thanks to this agent community!
-
-## Cite
-```bibtex
-@misc{openmanus2025,
-  author = {Xinbin Liang and Jinyu Xiang and Zhaoyang Yu and Jiayi Zhang and Sirui Hong},
-  title = {OpenManus: An open-source framework for building general AI agents},
-  year = {2025},
-  publisher = {GitHub},
-  journal = {GitHub repository},
-  howpublished = {\url{https://github.com/mannaandpoem/OpenManus}},
-}
-```
+Built on [OpenManus](https://github.com/mannaandpoem/OpenManus) by the MetaGPT team.
+Browser tooling via [browser-use](https://github.com/browser-use/browser-use).

--- a/app.py
+++ b/app.py
@@ -156,6 +156,8 @@ async def history_partial(request: Request):
             "request": request,
             "tasks": sorted_tasks[:20],
             "total_savings": stats.get("alltime_saved_usd", 0.0),
+            "tasks_completed": stats.get("tasks_completed", 0),
+            "most_used_agent": stats.get("most_used_agent"),
         },
     )
 

--- a/app.py
+++ b/app.py
@@ -155,7 +155,7 @@ async def history_partial(request: Request):
         {
             "request": request,
             "tasks": sorted_tasks[:20],
-            "total_savings": stats.get("total_savings_usd", 0.0),
+            "total_savings": stats.get("alltime_saved_usd", 0.0),
         },
     )
 

--- a/app.py
+++ b/app.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from json import dumps
 from typing import Optional
 
+import httpx as _httpx
+
 from fastapi import Body, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
@@ -83,16 +85,47 @@ class TaskManager:
 task_manager = TaskManager()
 
 
+async def _check_ollama() -> bool:
+    try:
+        async with _httpx.AsyncClient() as c:
+            r = await c.get("http://localhost:11434", timeout=2.0)
+            return r.status_code < 500
+    except Exception:
+        return False
+
+
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    ollama_ok = await _check_ollama()
+    return templates.TemplateResponse(
+        "index.html", {"request": request, "ollama_ok": ollama_ok}
+    )
+
+
+@app.get("/health/ollama")
+async def health_ollama():
+    ok = await _check_ollama()
+    if ok:
+        return {"status": "ok"}
+    return JSONResponse({"status": "unavailable"}, status_code=503)
 
 
 @app.post("/tasks")
 async def create_task(prompt: str = Body(..., embed=True)):
+    from app.router import classify
+
+    route = classify(prompt)
     task = task_manager.create_task(prompt)
+    if route.is_complex:
+        task_manager.tasks[task.id].status = "pending_approval"
+        return {
+            "task_id": task.id,
+            "requires_approval": True,
+            "estimated_cost": 0.04,
+            "model": "gpt-4o",
+        }
     asyncio.create_task(run_task(task.id, prompt))
-    return {"task_id": task.id}
+    return {"task_id": task.id, "requires_approval": False}
 
 
 import app.cost_service as _cost_service_module
@@ -109,6 +142,78 @@ async def run_task(task_id: str, prompt: str):
         await task_manager.complete_task(task_id)
     except Exception as e:
         await task_manager.fail_task(task_id, str(e))
+
+
+@app.get("/partials/history", response_class=HTMLResponse)
+async def history_partial(request: Request):
+    sorted_tasks = sorted(
+        task_manager.tasks.values(), key=lambda t: t.created_at, reverse=True
+    )
+    stats = _cost_service_module.cost_service.get_stats()
+    return templates.TemplateResponse(
+        "partials/history.html",
+        {
+            "request": request,
+            "tasks": sorted_tasks[:20],
+            "total_savings": stats.get("total_savings_usd", 0.0),
+        },
+    )
+
+
+@app.get("/partials/task-running", response_class=HTMLResponse)
+async def task_running_partial(request: Request, task_id: str):
+    return templates.TemplateResponse(
+        "partials/task-running.html", {"request": request, "task_id": task_id}
+    )
+
+
+@app.get("/partials/task-complete", response_class=HTMLResponse)
+async def task_complete_partial(request: Request, task_id: str):
+    task = task_manager.tasks.get(task_id)
+    output = ""
+    if task and task.steps:
+        for step in reversed(task.steps):
+            if step.get("type") == "run":
+                output = step.get("result", "")
+                break
+    return templates.TemplateResponse(
+        "partials/task-complete.html", {"request": request, "output": output}
+    )
+
+
+@app.get("/partials/cloud-dialog", response_class=HTMLResponse)
+async def cloud_dialog_partial(
+    request: Request, task_id: str, cost: float = 0.04, model: str = "gpt-4o"
+):
+    return templates.TemplateResponse(
+        "partials/cloud-dialog.html",
+        {"request": request, "task_id": task_id, "estimated_cost": cost, "model": model},
+    )
+
+
+@app.get("/classify")
+async def classify_prompt(prompt: str = ""):
+    from app.router import classify, FAST_LOCAL, SMART_LOCAL, CODE_EXPERT
+
+    LABEL_MAP = {
+        FAST_LOCAL: "Fast Local",
+        SMART_LOCAL: "Smart Local",
+        CODE_EXPERT: "Code Expert",
+    }
+    route = classify(prompt)
+    return {"model_key": route.model_key, "label": LABEL_MAP.get(route.model_key, "Cloud")}
+
+
+@app.post("/tasks/cloud-approve", response_class=HTMLResponse)
+async def cloud_approve(request: Request, task_id: str = Body(..., embed=True)):
+    if task_id not in task_manager.tasks:
+        raise HTTPException(status_code=404, detail="Task not found")
+    prompt = task_manager.tasks[task_id].prompt
+    task_manager.tasks[task_id].status = "pending"
+    asyncio.create_task(run_task(task_id, prompt))
+    return templates.TemplateResponse(
+        "partials/task-running.html", {"request": request, "task_id": task_id}
+    )
 
 
 @app.get("/tasks/{task_id}/events")

--- a/docs/superpowers/specs/2026-06-14-ui-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-14-ui-redesign-design.md
@@ -1,0 +1,200 @@
+# AaplaManus v2 — Plan 3: UI Redesign Design
+
+**Date:** 2026-06-14
+**Status:** Design approved, pending implementation plan
+**Repo:** https://github.com/swapniltamse/AaplaManus
+**Branch:** v2/foundation
+
+---
+
+## Goal
+
+Replace the inherited OpenManus HTML/JS with a clean HTMX-driven interface. Target audience: tech executives and non-technical users who are encountering local AI for the first time. The UI is a gateway — it must feel trustworthy, premium, and legible without requiring technical literacy.
+
+---
+
+## Design Decisions (from brainstorming)
+
+| Screen | Decision |
+|---|---|
+| Home screen | Mission Dashboard — two-panel layout |
+| Task running | Narrative Feed — plain-English sentence per event |
+| Setup flow | Full-screen wizard, leads with value proposition |
+| Cloud dialog | Privacy-First — "Data will leave this device" headline |
+| Tooltips | Alpine.js toggle, hardcoded content |
+
+---
+
+## Architecture
+
+**Tech stack:** HTMX 2.x (CDN), Jinja2 templates (already in FastAPI), Alpine.js 3.x (CDN, tooltips only), ~50 lines of vanilla JS (SSE connector only).
+
+**File structure:**
+
+```
+templates/
+  base.html                  # shared layout, HTMX + Alpine CDN, dark theme link
+  index.html                 # home: two-panel dashboard
+  partials/
+    history.html             # left panel — recent missions list
+    mission-input.html       # right panel — textarea + model indicator
+    task-running.html        # narrative feed container
+    task-complete.html       # final output card with copy button
+    setup-wizard.html        # full-screen first-run overlay
+    cloud-dialog.html        # privacy-first cloud approval modal
+
+static/
+  style.css                  # rewritten — dark theme, CSS custom properties, no inline styles
+  main.js                    # ~50 lines: SSE connector + narrative line appender only
+```
+
+**New endpoints in `app.py`:**
+
+```python
+GET  /health/ollama          # 200 {"status":"ok"} or 503 {"status":"unavailable"}
+GET  /partials/history       # renders partials/history.html — HTMX swap target
+POST /tasks/cloud-approve    # accepts {task_id} — starts task on cloud model
+```
+
+`POST /tasks` gains a new response path: when SmartRouter sets `is_complex=True` and no cloud approval exists, returns HTTP 202 with:
+```json
+{"task_id": "...", "requires_approval": true, "estimated_cost": 0.04, "model": "gpt-4o"}
+```
+The response also sets `HX-Trigger: show-cloud-dialog` header so HTMX swaps in the cloud dialog partial automatically.
+
+---
+
+## Screens
+
+### Home — Mission Dashboard
+
+Two-panel layout. Left panel loads on page load via `hx-get="/partials/history" hx-trigger="load"`. Each history item shows: prompt text (truncated to 60 chars), agent names used, dollars saved. Right panel contains the mission input textarea with `hx-post="/tasks" hx-target="#right-panel" hx-swap="innerHTML"`. Model indicator below the textarea reads from SmartRouter classification on keyup (debounced 500ms). Each model label has a `[?]` tooltip.
+
+### Task Running — Narrative Feed
+
+Right panel swaps to `task-running.html` after task submission. Contains an empty `<div id="feed">` that JS populates via SSE. Each event appends a `<div class="feed-line {type}">`. Event-to-sentence mapping:
+
+| SSE event type | Displayed sentence |
+|---|---|
+| `think` | "Manus is thinking through your request..." |
+| `tool` | "Using a tool..." |
+| `act` | "Taking action..." |
+| `run` | The literal `result` field from the event |
+| `complete` | Panel swaps to `task-complete.html` |
+| `error` | Red feed line with the error message |
+
+Done lines get `.done` class (checkmark prefix, gray text). Active line gets `.active` class (blinking cursor appended). Savings counter updates on each event from cumulative token count.
+
+On `complete` event: JS calls `htmx.trigger("#history-panel", "refresh")` to reload the left panel. No full page reload.
+
+### Setup Wizard — First Run
+
+On page load, `hx-get="/health/ollama" hx-trigger="load" hx-target="#main-content" hx-swap="innerHTML"` fires. If Ollama returns 503, the response body is `setup-wizard.html` which replaces the entire main content area.
+
+Wizard layout (full screen, centered):
+1. Green status dot + "Local AI System" label
+2. "AaplaManus" heading
+3. Three stat blocks: $0 API Cost / 0 Data Sent Out / Runs on Your Hardware
+4. One-sentence explanation of Ollama
+5. "Download Ollama — Free" button (links to ollama.com)
+6. "I installed it — continue" button → fires `hx-get="/health/ollama"` again
+
+If the re-check returns 200, the wizard swaps out and the normal dashboard loads. If still 503, inline error: "Still not detected. Try restarting Ollama, then click again."
+
+### Cloud Approval Dialog
+
+Triggered by `HX-Trigger: show-cloud-dialog` response header from `POST /tasks`. HTMX swaps `cloud-dialog.html` into `#right-panel`.
+
+Dialog elements:
+- Amber dot + "Data will leave this device" headline
+- Body: "Sending to {model}. Your prompt and any attached files will be processed on external servers."
+- Cost row: "Estimated cost" / "$0.04"
+- Primary button: "Approve and send to cloud" → `hx-post="/tasks/cloud-approve"`
+- Secondary button: "Run locally instead" → re-submits with `force_local=true`
+
+### Tooltips
+
+`[?]` spans use `x-data="{ open: false }"` and `@click="open = !open"` (Alpine.js). Tooltip body is a sibling `<div x-show="open">` with hardcoded plain-English text. No server round-trip.
+
+Tooltip copy:
+- **Ollama** — "Runs AI on your computer so nothing is sent to the internet"
+- **Agent** — "AI that takes actions, not just answers questions"
+- **Fast Local** — "Quick answers. Great for summaries. Runs on your device."
+- **Smart Local** — "More powerful. Best for research and complex tasks. Still local."
+- **Code Expert** — "Specialized for writing and running code. Runs locally."
+- **Cloud** — "Sends your request to an external AI service. Costs money. Your data leaves this device."
+
+---
+
+## Data Flow
+
+```
+User submits prompt
+  → hx-post="/tasks"
+  → FastAPI: SmartRouter classifies
+    → if complex + no approval: return 202 + HX-Trigger: show-cloud-dialog
+    → else: create task, start orchestrator, return 200 {task_id}
+  → HTMX swaps right panel to task-running.html
+  → main.js opens EventSource("/tasks/{task_id}/events")
+  → each event: appendNarrativeLine(label, type)
+  → on complete: htmx.trigger("#history-panel", "refresh")
+```
+
+SSE connector (full `main.js`):
+
+```javascript
+const LABELS = {
+  think: "Manus is thinking through your request...",
+  tool:  "Using a tool...",
+  act:   "Taking action...",
+};
+
+function connectSSE(taskId) {
+  const feed = document.getElementById("feed");
+  const source = new EventSource(`/tasks/${taskId}/events`);
+
+  source.onmessage = (e) => {
+    const data = JSON.parse(e.data);
+    if (data.type === "complete") {
+      htmx.ajax("GET", `/tasks/${taskId}`, { target: "#right-panel", swap: "innerHTML" });
+      htmx.trigger("#history-panel", "refresh");
+      source.close();
+      return;
+    }
+    const line = document.createElement("div");
+    line.className = `feed-line ${data.type}`;
+    line.textContent = LABELS[data.type] ?? data.result;
+    feed.appendChild(line);
+    feed.scrollTop = feed.scrollHeight;
+  };
+
+  source.onerror = () => source.close();
+}
+```
+
+---
+
+## Testing
+
+**Target:** 8 new tests across 2 new test files. 42 existing tests must continue to pass.
+
+**`tests/test_ui_routes.py`** (5 tests):
+- `test_home_returns_htmx_form` — GET / contains `hx-post="/tasks"`
+- `test_ollama_health_ok` — GET /health/ollama returns 200 when Ollama mock responds
+- `test_ollama_health_unavailable` — GET /health/ollama returns 503 on timeout
+- `test_complex_task_returns_202` — POST /tasks with complex prompt returns 202 + `requires_approval`
+- `test_cloud_approve_starts_task` — POST /tasks/cloud-approve returns 200 with `task_id`
+
+**`tests/test_templates.py`** (3 tests):
+- `test_setup_wizard_contains_value_props` — setup-wizard.html contains "$0", "0 Data Sent Out", "Runs on Your Hardware"
+- `test_cloud_dialog_privacy_language` — cloud-dialog.html contains "Data will leave this device" and "Approve and send to cloud"
+- `test_history_partial_renders_savings` — /partials/history returns HTML with savings amount from CostService
+
+---
+
+## What is not in Plan 3
+
+- Model pull progress bar (first Ollama model download) — Plan 4
+- Desktop app packaging (Tauri) — Plan 6
+- Mobile responsiveness — deferred
+- Dark/light theme toggle — deferred

--- a/docs/superpowers/specs/2026-06-14-ui-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-14-ui-redesign-design.md
@@ -53,6 +53,7 @@ static/
 ```python
 GET  /health/ollama          # 200 {"status":"ok"} or 503 {"status":"unavailable"}
 GET  /partials/history       # renders partials/history.html — HTMX swap target
+GET  /classify               # ?prompt=... → {"model": "Fast Local", "label": "Fast Local"} — drives model indicator
 POST /tasks/cloud-approve    # accepts {task_id} — starts task on cloud model
 ```
 

--- a/docs/superpowers/specs/2026-06-17-cost-dashboard-design.md
+++ b/docs/superpowers/specs/2026-06-17-cost-dashboard-design.md
@@ -1,0 +1,116 @@
+# Cost Dashboard — Real-Time Savings Counter Design
+
+**Date:** 2026-06-17
+**Status:** Approved
+**Branch:** v2/foundation
+
+---
+
+## Goal
+
+Wire the live savings counter in the task-running screen and add session stats (tasks completed, most used agent) to the history sidebar. Both use data already produced by `CostService` and already available at `GET /dashboard/stats`.
+
+## Architecture
+
+No new files. Three existing locations change:
+
+- `static/main.js` — interval inside `connectSSE()` polls `/dashboard/stats?session_id=taskId` every 2s
+- `templates/partials/history.html` — two new stat lines below the savings total
+- `app.py` (`GET /partials/history`) — pass `tasks_completed` and `most_used_agent` to template
+
+`CostService`, agents, and the SSE stream are untouched.
+
+---
+
+## Live Counter
+
+`connectSSE(taskId)` in `main.js` starts an interval after registering SSE listeners:
+
+```js
+const statsInterval = setInterval(async () => {
+  const r = await fetch(`/dashboard/stats?session_id=${taskId}`);
+  const data = await r.json();
+  const el = document.getElementById("savings-live");
+  if (el) el.textContent = `Saved $${data.session_saved_usd.toFixed(2)} so far`;
+}, 2000);
+```
+
+`clearInterval(statsInterval)` is added to both the `complete` handler and the `error` handler, before their existing HTMX swap calls. The interval is scoped inside `connectSSE` — no globals, no leaks between tasks.
+
+The `#savings-live` div already exists in `task-running.html` with hardcoded `$0.00`. No template change needed for the counter.
+
+---
+
+## Sidebar Stats
+
+`GET /partials/history` already calls `cost_service.get_stats()`. Pass the full result:
+
+```python
+stats = _cost_service_module.cost_service.get_stats()
+return templates.TemplateResponse(
+    "partials/history.html",
+    {
+        "request": request,
+        "tasks": sorted_tasks[:20],
+        "total_savings": stats.get("alltime_saved_usd", 0.0),
+        "tasks_completed": stats.get("tasks_completed", 0),
+        "most_used_agent": stats.get("most_used_agent"),
+    },
+)
+```
+
+`history.html` gains two lines below the existing savings total:
+
+```html
+<div class="savings-total">Saved ${{ "%.2f"|format(total_savings) }} total</div>
+<div class="stat-line">{{ tasks_completed }} tasks completed</div>
+{% if most_used_agent %}
+<div class="stat-line">Most used: {{ most_used_agent }}</div>
+{% endif %}
+```
+
+Stats refresh automatically after every mission because `htmx.trigger("#history-panel", "refresh")` already fires on task complete in `main.js`.
+
+---
+
+## Testing
+
+3 new tests (50 existing + 3 = 53 total). All in `test_ui_routes.py`.
+
+```python
+def test_history_partial_includes_task_count(client):
+    with patch.object(
+        app_module._cost_service_module.cost_service,
+        "get_stats",
+        return_value={"alltime_saved_usd": 0.0, "tasks_completed": 5, "most_used_agent": None},
+    ):
+        response = client.get("/partials/history")
+    assert "5 tasks completed" in response.text
+
+
+def test_history_partial_includes_most_used_agent(client):
+    with patch.object(
+        app_module._cost_service_module.cost_service,
+        "get_stats",
+        return_value={"alltime_saved_usd": 0.0, "tasks_completed": 1, "most_used_agent": "research_agent"},
+    ):
+        response = client.get("/partials/history")
+    assert "Most used: research_agent" in response.text
+
+
+def test_dashboard_stats_session_savings_defaults_to_zero(client):
+    response = client.get("/dashboard/stats?session_id=nonexistent-id")
+    assert response.status_code == 200
+    assert response.json()["session_saved_usd"] == 0.0
+```
+
+JS interval logic is not unit-tested. Coverage comes from the manual flow: run a task, watch the counter update. The endpoint the interval calls is already covered by existing tests.
+
+---
+
+## What Is Not In Scope
+
+- CSS styling for `.stat-line` beyond what already exists in `style.css`
+- Alltime token count display
+- Per-agent breakdown table
+- WebSocket push (polling is sufficient at 2s cadence)

--- a/docs/superpowers/specs/2026-06-17-cost-dashboard-design.md
+++ b/docs/superpowers/specs/2026-06-17-cost-dashboard-design.md
@@ -108,9 +108,20 @@ JS interval logic is not unit-tested. Coverage comes from the manual flow: run a
 
 ---
 
+## CSS
+
+Add one rule to `style.css` for the new stat lines:
+
+```css
+.stat-line {
+  font-size: 0.75rem;
+  color: var(--muted, #64748b);
+  margin-top: 0.25rem;
+}
+```
+
 ## What Is Not In Scope
 
-- CSS styling for `.stat-line` beyond what already exists in `style.css`
 - Alltime token count display
 - Per-agent breakdown table
 - WebSocket push (polling is sufficient at 2s cadence)

--- a/static/main.js
+++ b/static/main.js
@@ -67,6 +67,15 @@ function connectSSE(taskId) {
   const source = new EventSource(`/tasks/${taskId}/events`);
   let activeLine = null;
 
+  const statsInterval = setInterval(async () => {
+    try {
+      const r = await fetch(`/dashboard/stats?session_id=${taskId}`);
+      const data = await r.json();
+      const el = document.getElementById("savings-live");
+      if (el) el.textContent = `Saved $${data.session_saved_usd.toFixed(2)} so far`;
+    } catch (_) {}
+  }, 2000);
+
   // Server sends explicit `event:` names (think/tool/act/run/step/complete/error),
   // so onmessage never fires — EventSource only invokes it for unnamed "message" events.
   const handleStep = (e) => {
@@ -83,6 +92,7 @@ function connectSSE(taskId) {
   });
 
   source.addEventListener("complete", () => {
+    clearInterval(statsInterval);
     source.close();
     htmx.ajax("GET", `/partials/task-complete?task_id=${taskId}`, {
       target: "#right-panel",
@@ -94,6 +104,7 @@ function connectSSE(taskId) {
   // "error" fires both for the server's named error event (has e.data) and for
   // native connection failures (no e.data) — EventSource treats both as the same type.
   source.addEventListener("error", (e) => {
+    clearInterval(statsInterval);
     if (e.data) {
       const data = JSON.parse(e.data);
       appendLine(feed, data.message || "An error occurred.", "error");

--- a/static/main.js
+++ b/static/main.js
@@ -116,7 +116,7 @@ function connectSSE(taskId) {
     source.close();
   });
 
-  return () => clearInterval(statsInterval);
+  return () => { clearInterval(statsInterval); source.close(); };
 }
 
 function appendLine(feed, text, cssClass) {

--- a/static/main.js
+++ b/static/main.js
@@ -1,694 +1,106 @@
-let currentEventSource = null;
+const LABELS = {
+  think: "Manus is thinking through your request...",
+  tool:  "Using a tool...",
+  act:   "Taking action...",
+};
 
-function createTask() {
-    const promptInput = document.getElementById('prompt-input');
-    const prompt = promptInput.value.trim();
+document.addEventListener("DOMContentLoaded", () => {
+  const form = document.getElementById("mission-form");
+  if (!form) return;
 
-    if (!prompt) {
-        alert("Please enter a valid prompt");
-        promptInput.focus();
-        return;
-    }
+  const promptInput = document.getElementById("prompt-input");
+  const modelLabel  = document.getElementById("model-label");
 
-    if (currentEventSource) {
-        currentEventSource.close();
-        currentEventSource = null;
-    }
-
-    const container = document.getElementById('task-container');
-    container.innerHTML = '<div class="loading">Initializing task...</div>';
-    document.getElementById('input-container').classList.add('bottom');
-
-    fetch('/tasks', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ prompt })
-    })
-    .then(response => {
-        if (!response.ok) {
-            return response.json().then(err => { throw new Error(err.detail || 'Request failed') });
-        }
-        return response.json();
-    })
-    .then(data => {
-        if (!data.task_id) {
-            throw new Error('Invalid task ID');
-        }
-        setupSSE(data.task_id);
-        loadHistory();
-    })
-    .catch(error => {
-        container.innerHTML = `<div class="error">Error: ${error.message}</div>`;
-        console.error('Failed to create task:', error);
+  let debounceTimer;
+  if (promptInput && modelLabel) {
+    promptInput.addEventListener("input", () => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(async () => {
+        const prompt = promptInput.value.trim();
+        if (!prompt) return;
+        const res  = await fetch(`/classify?prompt=${encodeURIComponent(prompt)}`);
+        const data = await res.json();
+        modelLabel.textContent = data.label;
+      }, 500);
     });
-}
+  }
 
-function setupSSE(taskId) {
-    let retryCount = 0;
-    const maxRetries = 3;
-    const retryDelay = 2000;
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const prompt = promptInput ? promptInput.value.trim() : "";
+    if (!prompt) return;
 
-    function connect() {
-        const eventSource = new EventSource(`/tasks/${taskId}/events`);
-        currentEventSource = eventSource;
-
-        const container = document.getElementById('task-container');
-
-        let heartbeatTimer = setInterval(() => {
-            container.innerHTML += '<div class="ping">·</div>';
-        }, 5000);
-
-        const pollInterval = setInterval(() => {
-            fetch(`/tasks/${taskId}`)
-                .then(response => response.json())
-                .then(task => {
-                    updateTaskStatus(task);
-                })
-                .catch(error => {
-                    console.error('Polling failed:', error);
-                });
-        }, 10000);
-
-    if (!eventSource._listenersAdded) {
-        eventSource._listenersAdded = true;
-
-        let lastResultContent = '';
-        eventSource.addEventListener('status', (event) => {
-            clearInterval(heartbeatTimer);
-            try {
-                const data = JSON.parse(event.data);
-                container.querySelector('.loading')?.remove();
-                container.classList.add('active');
-                const welcomeMessage = document.querySelector('.welcome-message');
-                if (welcomeMessage) {
-                    welcomeMessage.style.display = 'none';
-                }
-
-                let stepContainer = container.querySelector('.step-container');
-                if (!stepContainer) {
-                    container.innerHTML = '<div class="step-container"></div>';
-                    stepContainer = container.querySelector('.step-container');
-                }
-
-                // Save result content
-                if (data.steps && data.steps.length > 0) {
-                    // Iterate through all steps, find the last result type
-                    for (let i = data.steps.length - 1; i >= 0; i--) {
-                        if (data.steps[i].type === 'result') {
-                            lastResultContent = data.steps[i].result;
-                            break;
-                        }
-                    }
-                }
-
-                // Parse and display each step with proper formatting
-                stepContainer.innerHTML = data.steps.map(step => {
-                    const content = step.result;
-                    const timestamp = new Date().toLocaleTimeString();
-                    return `
-                        <div class="step-item ${step.type || 'step'}">
-                            <div class="log-line">
-                                <span class="log-prefix">${getEventIcon(step.type)} [${timestamp}] ${getEventLabel(step.type)}:</span>
-                                <pre>${content}</pre>
-                            </div>
-                        </div>
-                    `;
-                }).join('');
-
-                // Auto-scroll to bottom
-                container.scrollTo({
-                    top: container.scrollHeight,
-                    behavior: 'smooth'
-                });
-            } catch (e) {
-                console.error('Status update failed:', e);
-            }
-        });
-
-        // Add handler for think event
-        eventSource.addEventListener('think', (event) => {
-            clearInterval(heartbeatTimer);
-            try {
-                const data = JSON.parse(event.data);
-                container.querySelector('.loading')?.remove();
-
-                let stepContainer = container.querySelector('.step-container');
-                if (!stepContainer) {
-                    container.innerHTML = '<div class="step-container"></div>';
-                    stepContainer = container.querySelector('.step-container');
-                }
-
-                const content = data.result;
-                const timestamp = new Date().toLocaleTimeString();
-
-                const step = document.createElement('div');
-                step.className = 'step-item think';
-                step.innerHTML = `
-                    <div class="log-line">
-                        <span class="log-prefix">${getEventIcon('think')} [${timestamp}] ${getEventLabel('think')}:</span>
-                        <pre>${content}</pre>
-                    </div>
-                `;
-
-                stepContainer.appendChild(step);
-                container.scrollTo({
-                    top: container.scrollHeight,
-                    behavior: 'smooth'
-                });
-
-                // Update task status
-                fetch(`/tasks/${taskId}`)
-                    .then(response => response.json())
-                    .then(task => {
-                        updateTaskStatus(task);
-                    })
-                    .catch(error => {
-                        console.error('Status update failed:', error);
-                    });
-            } catch (e) {
-                console.error('Think event handling failed:', e);
-            }
-        });
-
-        // Add handler for tool event
-        eventSource.addEventListener('tool', (event) => {
-            clearInterval(heartbeatTimer);
-            try {
-                const data = JSON.parse(event.data);
-                container.querySelector('.loading')?.remove();
-
-                let stepContainer = container.querySelector('.step-container');
-                if (!stepContainer) {
-                    container.innerHTML = '<div class="step-container"></div>';
-                    stepContainer = container.querySelector('.step-container');
-                }
-
-                const content = data.result;
-                const timestamp = new Date().toLocaleTimeString();
-
-                const step = document.createElement('div');
-                step.className = 'step-item tool';
-                step.innerHTML = `
-                    <div class="log-line">
-                        <span class="log-prefix">${getEventIcon('tool')} [${timestamp}] ${getEventLabel('tool')}:</span>
-                        <pre>${content}</pre>
-                    </div>
-                `;
-
-                stepContainer.appendChild(step);
-                container.scrollTo({
-                    top: container.scrollHeight,
-                    behavior: 'smooth'
-                });
-
-                // Update task status
-                fetch(`/tasks/${taskId}`)
-                    .then(response => response.json())
-                    .then(task => {
-                        updateTaskStatus(task);
-                    })
-                    .catch(error => {
-                        console.error('Status update failed:', error);
-                    });
-            } catch (e) {
-                console.error('Tool event handling failed:', e);
-            }
-        });
-
-        // Add handler for act event
-        eventSource.addEventListener('act', (event) => {
-            clearInterval(heartbeatTimer);
-            try {
-                const data = JSON.parse(event.data);
-                container.querySelector('.loading')?.remove();
-
-                let stepContainer = container.querySelector('.step-container');
-                if (!stepContainer) {
-                    container.innerHTML = '<div class="step-container"></div>';
-                    stepContainer = container.querySelector('.step-container');
-                }
-
-                const content = data.result;
-                const timestamp = new Date().toLocaleTimeString();
-
-                const step = document.createElement('div');
-                step.className = 'step-item act';
-                step.innerHTML = `
-                    <div class="log-line">
-                        <span class="log-prefix">${getEventIcon('act')} [${timestamp}] ${getEventLabel('act')}:</span>
-                        <pre>${content}</pre>
-                    </div>
-                `;
-
-                stepContainer.appendChild(step);
-                container.scrollTo({
-                    top: container.scrollHeight,
-                    behavior: 'smooth'
-                });
-
-                // Update task status
-                fetch(`/tasks/${taskId}`)
-                    .then(response => response.json())
-                    .then(task => {
-                        updateTaskStatus(task);
-                    })
-                    .catch(error => {
-                        console.error('Status update failed:', error);
-                    });
-            } catch (e) {
-                console.error('Act event handling failed:', e);
-            }
-        });
-
-        // Add handler for log event
-        eventSource.addEventListener('log', (event) => {
-            clearInterval(heartbeatTimer);
-            try {
-                const data = JSON.parse(event.data);
-                container.querySelector('.loading')?.remove();
-
-                let stepContainer = container.querySelector('.step-container');
-                if (!stepContainer) {
-                    container.innerHTML = '<div class="step-container"></div>';
-                    stepContainer = container.querySelector('.step-container');
-                }
-
-                const content = data.result;
-                const timestamp = new Date().toLocaleTimeString();
-
-                const step = document.createElement('div');
-                step.className = 'step-item log';
-                step.innerHTML = `
-                    <div class="log-line">
-                        <span class="log-prefix">${getEventIcon('log')} [${timestamp}] ${getEventLabel('log')}:</span>
-                        <pre>${content}</pre>
-                    </div>
-                `;
-
-                stepContainer.appendChild(step);
-                container.scrollTo({
-                    top: container.scrollHeight,
-                    behavior: 'smooth'
-                });
-
-                // Update task status
-                fetch(`/tasks/${taskId}`)
-                    .then(response => response.json())
-                    .then(task => {
-                        updateTaskStatus(task);
-                    })
-                    .catch(error => {
-                        console.error('Status update failed:', error);
-                    });
-            } catch (e) {
-                console.error('Log event handling failed:', e);
-            }
-        });
-
-        eventSource.addEventListener('run', (event) => {
-            clearInterval(heartbeatTimer);
-            try {
-                const data = JSON.parse(event.data);
-                container.querySelector('.loading')?.remove();
-
-                let stepContainer = container.querySelector('.step-container');
-                if (!stepContainer) {
-                    container.innerHTML = '<div class="step-container"></div>';
-                    stepContainer = container.querySelector('.step-container');
-                }
-
-                const content = data.result;
-                const timestamp = new Date().toLocaleTimeString();
-
-                const step = document.createElement('div');
-                step.className = 'step-item run';
-                step.innerHTML = `
-                    <div class="log-line">
-                        <span class="log-prefix">${getEventIcon('run')} [${timestamp}] ${getEventLabel('run')}:</span>
-                        <pre>${content}</pre>
-                    </div>
-                `;
-
-                stepContainer.appendChild(step);
-                container.scrollTo({
-                    top: container.scrollHeight,
-                    behavior: 'smooth'
-                });
-
-                // Update task status
-                fetch(`/tasks/${taskId}`)
-                    .then(response => response.json())
-                    .then(task => {
-                        updateTaskStatus(task);
-                    })
-                    .catch(error => {
-                        console.error('Status update failed:', error);
-                    });
-            } catch (e) {
-                console.error('Run event handling failed:', e);
-            }
-        });
-
-        eventSource.addEventListener('message', (event) => {
-            clearInterval(heartbeatTimer);
-            try {
-                const data = JSON.parse(event.data);
-                container.querySelector('.loading')?.remove();
-
-                let stepContainer = container.querySelector('.step-container');
-                if (!stepContainer) {
-                    container.innerHTML = '<div class="step-container"></div>';
-                    stepContainer = container.querySelector('.step-container');
-                }
-
-                // Create new step element
-                const step = document.createElement('div');
-                step.className = `step-item ${data.type || 'step'}`;
-
-                // Format content and timestamp
-                const content = data.result;
-                const timestamp = new Date().toLocaleTimeString();
-
-                step.innerHTML = `
-                    <div class="log-line ${data.type || 'info'}">
-                        <span class="log-prefix">${getEventIcon(data.type)} [${timestamp}] ${getEventLabel(data.type)}:</span>
-                        <pre>${content}</pre>
-                    </div>
-                `;
-
-                // Add step to container with animation
-                stepContainer.prepend(step);
-                setTimeout(() => {
-                    step.classList.add('show');
-                }, 10);
-
-                // Auto-scroll to bottom
-                container.scrollTo({
-                    top: container.scrollHeight,
-                    behavior: 'smooth'
-                });
-            } catch (e) {
-                console.error('Message handling failed:', e);
-            }
-        });
-
-        let isTaskComplete = false;
-
-        eventSource.addEventListener('complete', (event) => {
-            isTaskComplete = true;
-            clearInterval(heartbeatTimer);
-            clearInterval(pollInterval);
-            container.innerHTML += `
-                <div class="complete">
-                    <div>✅ Task completed</div>
-                    <pre>${lastResultContent}</pre>
-                </div>
-            `;
-            eventSource.close();
-            currentEventSource = null;
-            lastResultContent = ''; // Clear result content
-        });
-
-        eventSource.addEventListener('error', (event) => {
-            clearInterval(heartbeatTimer);
-            clearInterval(pollInterval);
-            try {
-                const data = JSON.parse(event.data);
-                container.innerHTML += `
-                    <div class="error">
-                        ❌ Error: ${data.message}
-                    </div>
-                `;
-                eventSource.close();
-                currentEventSource = null;
-            } catch (e) {
-                console.error('Error handling failed:', e);
-            }
-        });
-    }
-
-    container.scrollTo({
-        top: container.scrollHeight,
-        behavior: 'smooth'
+    const res  = await fetch("/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt }),
     });
+    const data = await res.json();
 
-        eventSource.onerror = (err) => {
-            if (isTaskComplete) {
-                return;
-            }
-
-            console.error('SSE connection error:', err);
-            clearInterval(heartbeatTimer);
-            clearInterval(pollInterval);
-            eventSource.close();
-
-            if (retryCount < maxRetries) {
-                retryCount++;
-                container.innerHTML += `
-                    <div class="warning">
-                        ⚠ Connection lost, retrying in ${retryDelay/1000} seconds (${retryCount}/${maxRetries})...
-                    </div>
-                `;
-                setTimeout(connect, retryDelay);
-            } else {
-                container.innerHTML += `
-                    <div class="error">
-                        ⚠ Connection lost, please try refreshing the page
-                    </div>
-                `;
-            }
-        };
-    }
-
-    connect();
-}
-
-function getEventIcon(eventType) {
-    switch(eventType) {
-        case 'think': return '🤔';
-        case 'tool': return '🛠️';
-        case 'act': return '🚀';
-        case 'result': return '🏁';
-        case 'error': return '❌';
-        case 'complete': return '✅';
-        case 'log': return '📝';
-        case 'run': return '⚙️';
-        default: return 'ℹ️';
-    }
-}
-
-function getEventLabel(eventType) {
-    switch(eventType) {
-        case 'think': return 'Thinking';
-        case 'tool': return 'Using Tool';
-        case 'act': return 'Action';
-        case 'result': return 'Result';
-        case 'error': return 'Error';
-        case 'complete': return 'Complete';
-        case 'log': return 'Log';
-        case 'run': return 'Running';
-        default: return 'Info';
-    }
-}
-
-function updateTaskStatus(task) {
-    const statusBar = document.getElementById('status-bar');
-    if (!statusBar) return;
-
-    if (task.status === 'completed') {
-        statusBar.innerHTML = `<span class="status-complete">✅ Task completed</span>`;
-    } else if (task.status === 'failed') {
-        statusBar.innerHTML = `<span class="status-error">❌ Task failed: ${task.error || 'Unknown error'}</span>`;
+    if (data.requires_approval) {
+      htmx.ajax(
+        "GET",
+        `/partials/cloud-dialog?task_id=${data.task_id}&cost=${data.estimated_cost}&model=${data.model}`,
+        { target: "#right-panel", swap: "innerHTML" }
+      );
     } else {
-        statusBar.innerHTML = `<span class="status-running">⚙️ Task running: ${task.status}</span>`;
+      htmx.ajax(
+        "GET",
+        `/partials/task-running?task_id=${data.task_id}`,
+        { target: "#right-panel", swap: "innerHTML" }
+      );
     }
-}
-
-function loadHistory() {
-    fetch('/tasks')
-        .then(response => {
-            if (!response.ok) {
-                throw new Error('Failed to load history');
-            }
-            return response.json();
-        })
-        .then(tasks => {
-            const historyContainer = document.getElementById('history-container');
-            if (!historyContainer) return;
-
-            historyContainer.innerHTML = '';
-
-            if (tasks.length === 0) {
-                historyContainer.innerHTML = '<div class="history-empty">No recent tasks</div>';
-                return;
-            }
-
-            const historyList = document.createElement('div');
-            historyList.className = 'history-list';
-
-            tasks.forEach(task => {
-                const taskItem = document.createElement('div');
-                taskItem.className = `history-item ${task.status}`;
-                taskItem.innerHTML = `
-                    <div class="history-prompt">${task.prompt}</div>
-                    <div class="history-meta">
-                        <span class="history-time">${new Date(task.created_at).toLocaleString()}</span>
-                        <span class="history-status">${getStatusIcon(task.status)}</span>
-                    </div>
-                `;
-                taskItem.addEventListener('click', () => {
-                    loadTask(task.id);
-                });
-                historyList.appendChild(taskItem);
-            });
-
-            historyContainer.appendChild(historyList);
-        })
-        .catch(error => {
-            console.error('Failed to load history:', error);
-            const historyContainer = document.getElementById('history-container');
-            if (historyContainer) {
-                historyContainer.innerHTML = `<div class="error">Failed to load history: ${error.message}</div>`;
-            }
-        });
-}
-
-function getStatusIcon(status) {
-    switch(status) {
-        case 'completed': return '✅';
-        case 'failed': return '❌';
-        case 'running': return '⚙️';
-        default: return '⏳';
-    }
-}
-
-function loadTask(taskId) {
-    if (currentEventSource) {
-        currentEventSource.close();
-        currentEventSource = null;
-    }
-
-    const container = document.getElementById('task-container');
-    container.innerHTML = '<div class="loading">Loading task...</div>';
-    document.getElementById('input-container').classList.add('bottom');
-
-    fetch(`/tasks/${taskId}`)
-        .then(response => {
-            if (!response.ok) {
-                throw new Error('Failed to load task');
-            }
-            return response.json();
-        })
-        .then(task => {
-            if (task.status === 'running') {
-                setupSSE(taskId);
-            } else {
-                displayTask(task);
-            }
-        })
-        .catch(error => {
-            console.error('Failed to load task:', error);
-            container.innerHTML = `<div class="error">Failed to load task: ${error.message}</div>`;
-        });
-}
-
-function displayTask(task) {
-    const container = document.getElementById('task-container');
-    container.innerHTML = '';
-    container.classList.add('active');
-
-    const welcomeMessage = document.querySelector('.welcome-message');
-    if (welcomeMessage) {
-        welcomeMessage.style.display = 'none';
-    }
-
-    const stepContainer = document.createElement('div');
-    stepContainer.className = 'step-container';
-
-    if (task.steps && task.steps.length > 0) {
-        task.steps.forEach(step => {
-            const stepItem = document.createElement('div');
-            stepItem.className = `step-item ${step.type || 'step'}`;
-
-            const content = step.result;
-            const timestamp = new Date(step.timestamp || task.created_at).toLocaleTimeString();
-
-            stepItem.innerHTML = `
-                <div class="log-line">
-                    <span class="log-prefix">${getEventIcon(step.type)} [${timestamp}] ${getEventLabel(step.type)}:</span>
-                    <pre>${content}</pre>
-                </div>
-            `;
-
-            stepContainer.appendChild(stepItem);
-        });
-    } else {
-        stepContainer.innerHTML = '<div class="no-steps">No steps recorded for this task</div>';
-    }
-
-    container.appendChild(stepContainer);
-
-    if (task.status === 'completed') {
-        let lastResultContent = '';
-        if (task.steps && task.steps.length > 0) {
-            for (let i = task.steps.length - 1; i >= 0; i--) {
-                if (task.steps[i].type === 'result') {
-                    lastResultContent = task.steps[i].result;
-                    break;
-                }
-            }
-        }
-
-        container.innerHTML += `
-            <div class="complete">
-                <div>✅ Task completed</div>
-                <pre>${lastResultContent}</pre>
-            </div>
-        `;
-    } else if (task.status === 'failed') {
-        container.innerHTML += `
-            <div class="error">
-                ❌ Error: ${task.error || 'Unknown error'}
-            </div>
-        `;
-    }
-
-    updateTaskStatus(task);
-}
-
-// Initialize the app when the DOM is loaded
-document.addEventListener('DOMContentLoaded', () => {
-    loadHistory();
-
-    // Set up event listeners
-    document.getElementById('create-task-btn').addEventListener('click', createTask);
-    document.getElementById('prompt-input').addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' && !e.shiftKey) {
-            e.preventDefault();
-            createTask();
-        }
-    });
-
-    // Show history button functionality
-    const historyToggle = document.getElementById('history-toggle');
-    if (historyToggle) {
-        historyToggle.addEventListener('click', () => {
-            const historyPanel = document.getElementById('history-panel');
-            if (historyPanel) {
-                historyPanel.classList.toggle('open');
-                historyToggle.classList.toggle('active');
-            }
-        });
-    }
-
-    // Clear button functionality
-    const clearButton = document.getElementById('clear-btn');
-    if (clearButton) {
-        clearButton.addEventListener('click', () => {
-            document.getElementById('prompt-input').value = '';
-            document.getElementById('prompt-input').focus();
-        });
-    }
+  });
 });
+
+document.addEventListener("htmx:afterSwap", () => {
+  const feed = document.getElementById("task-feed");
+  if (feed && feed.dataset.taskId) {
+    connectSSE(feed.dataset.taskId);
+  }
+});
+
+function connectSSE(taskId) {
+  const feed = document.getElementById("feed");
+  if (!feed) return;
+
+  const source = new EventSource(`/tasks/${taskId}/events`);
+  let activeLine = null;
+
+  source.onmessage = (e) => {
+    const data = JSON.parse(e.data);
+
+    if (data.type === "complete") {
+      source.close();
+      htmx.ajax("GET", `/partials/task-complete?task_id=${taskId}`, {
+        target: "#right-panel",
+        swap: "innerHTML",
+      });
+      htmx.trigger("#history-panel", "refresh");
+      return;
+    }
+
+    if (data.type === "error") {
+      appendLine(feed, data.message || "An error occurred.", "error");
+      source.close();
+      return;
+    }
+
+    if (activeLine) {
+      activeLine.classList.remove("active");
+      activeLine.classList.add("done");
+    }
+    activeLine = appendLine(feed, LABELS[data.type] ?? data.result, "active");
+    feed.scrollTop = feed.scrollHeight;
+  };
+
+  source.onerror = () => source.close();
+}
+
+function appendLine(feed, text, cssClass) {
+  const line = document.createElement("div");
+  line.className = `feed-line ${cssClass}`;
+  line.textContent = text;
+  feed.appendChild(line);
+  return line;
+}

--- a/static/main.js
+++ b/static/main.js
@@ -53,10 +53,13 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 });
 
+let _cleanupSSE = null;
+
 document.addEventListener("htmx:afterSwap", () => {
+  if (_cleanupSSE) { _cleanupSSE(); _cleanupSSE = null; }
   const feed = document.getElementById("task-feed");
   if (feed && feed.dataset.taskId) {
-    connectSSE(feed.dataset.taskId);
+    _cleanupSSE = connectSSE(feed.dataset.taskId);
   }
 });
 
@@ -72,7 +75,8 @@ function connectSSE(taskId) {
       const r = await fetch(`/dashboard/stats?session_id=${taskId}`);
       const data = await r.json();
       const el = document.getElementById("savings-live");
-      if (el) el.textContent = `Saved $${data.session_saved_usd.toFixed(2)} so far`;
+      const val = typeof data.session_saved_usd === "number" ? data.session_saved_usd : 0;
+      if (el) el.textContent = `Saved $${val.toFixed(2)} so far`;
     } catch (_) {}
   }, 2000);
 
@@ -111,6 +115,8 @@ function connectSSE(taskId) {
     }
     source.close();
   });
+
+  return () => clearInterval(statsInterval);
 }
 
 function appendLine(feed, text, cssClass) {

--- a/static/main.js
+++ b/static/main.js
@@ -67,25 +67,10 @@ function connectSSE(taskId) {
   const source = new EventSource(`/tasks/${taskId}/events`);
   let activeLine = null;
 
-  source.onmessage = (e) => {
+  // Server sends explicit `event:` names (think/tool/act/run/step/complete/error),
+  // so onmessage never fires — EventSource only invokes it for unnamed "message" events.
+  const handleStep = (e) => {
     const data = JSON.parse(e.data);
-
-    if (data.type === "complete") {
-      source.close();
-      htmx.ajax("GET", `/partials/task-complete?task_id=${taskId}`, {
-        target: "#right-panel",
-        swap: "innerHTML",
-      });
-      htmx.trigger("#history-panel", "refresh");
-      return;
-    }
-
-    if (data.type === "error") {
-      appendLine(feed, data.message || "An error occurred.", "error");
-      source.close();
-      return;
-    }
-
     if (activeLine) {
       activeLine.classList.remove("active");
       activeLine.classList.add("done");
@@ -93,8 +78,28 @@ function connectSSE(taskId) {
     activeLine = appendLine(feed, LABELS[data.type] ?? data.result, "active");
     feed.scrollTop = feed.scrollHeight;
   };
+  ["think", "tool", "act", "run", "step"].forEach((type) => {
+    source.addEventListener(type, handleStep);
+  });
 
-  source.onerror = () => source.close();
+  source.addEventListener("complete", () => {
+    source.close();
+    htmx.ajax("GET", `/partials/task-complete?task_id=${taskId}`, {
+      target: "#right-panel",
+      swap: "innerHTML",
+    });
+    htmx.trigger("#history-panel", "refresh");
+  });
+
+  // "error" fires both for the server's named error event (has e.data) and for
+  // native connection failures (no e.data) — EventSource treats both as the same type.
+  source.addEventListener("error", (e) => {
+    if (e.data) {
+      const data = JSON.parse(e.data);
+      appendLine(feed, data.message || "An error occurred.", "error");
+    }
+    source.close();
+  });
 }
 
 function appendLine(feed, text, cssClass) {

--- a/static/style.css
+++ b/static/style.css
@@ -1,338 +1,320 @@
 :root {
-    --primary-color: #007bff;
-    --primary-hover: #0056b3;
-    --success-color: #28a745;
-    --error-color: #dc3545;
-    --warning-color: #ff9800;
-    --info-color: #2196f3;
-    --text-color: #333;
-    --text-light: #666;
-    --bg-color: #f8f9fa;
-    --border-color: #ddd;
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --surface2: #1f2937;
+  --border: #334155;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --text-dim: #6b7280;
+  --accent: #3b82f6;
+  --green: #10b981;
+  --amber: #f59e0b;
+  --red: #ef4444;
+  --radius: 8px;
+  --font: system-ui, -apple-system, sans-serif;
 }
 
-* {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-}
+* { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-    font-family: 'PingFang SC', 'Microsoft YaHei', sans-serif;
-    margin: 0;
-    padding: 0;
-    background-color: var(--bg-color);
-    color: var(--text-color);
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 14px;
+  height: 100vh;
+  overflow: hidden;
 }
 
-.container {
-    display: flex;
-    min-height: 100vh;
-    width: 90%;
-    margin: 0 auto;
-    padding: 20px;
-    gap: 20px;
+[x-cloak] { display: none !important; }
+
+/* Layout */
+.layout { display: flex; height: 100vh; }
+
+.panel-left {
+  width: 240px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  padding: 20px 16px;
+  gap: 12px;
+  overflow-y: auto;
 }
 
-.card {
-    background-color: white;
-    border-radius: 8px;
-    padding: 20px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+.panel-right {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 28px 32px;
+  overflow-y: auto;
 }
 
-.history-panel {
-    width: 300px;
+/* History panel */
+.panel-left h2 {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 1px;
 }
 
-.main-panel {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
+.history-item {
+  padding: 8px 10px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  border: 1px solid transparent;
 }
 
-.task-list {
-    margin-top: 10px;
-    max-height: calc(100vh - 160px);
-    overflow-y: auto;
-    overflow-x: hidden;
+.history-item:hover { background: var(--surface); border-color: var(--border); }
+
+.history-prompt {
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.task-container {
-    @extend .card;
-    width: 100%;
-    position: relative;
-    min-height: 300px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    padding: 20px;
-    overflow: auto;
-    height: 100%;
+.history-status { font-size: 11px; color: var(--text-dim); margin-top: 3px; }
+.history-empty { font-size: 12px; color: var(--text-dim); font-style: italic; }
+
+.savings-total {
+  margin-top: auto;
+  font-size: 12px;
+  color: var(--green);
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
 }
 
-.welcome-message {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-    color: var(--text-light);
-    background: white;
-    z-index: 1;
-    padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    width: 100%;
-    height: 100%;
+/* Mission input */
+.mission-title { font-size: 22px; font-weight: 700; margin-bottom: 16px; }
+
+.mission-input {
+  width: 100%;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 14px;
+  padding: 12px 14px;
+  resize: vertical;
+  min-height: 80px;
+  outline: none;
 }
 
-.welcome-message h1 {
-    font-size: 2rem;
-    margin-bottom: 10px;
-    color: var(--text-color);
+.mission-input:focus { border-color: var(--accent); }
+.mission-input::placeholder { color: var(--text-dim); }
+
+.model-indicator {
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--text-dim);
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
 }
 
-.input-container {
-    @extend .card;
-    display: flex;
-    gap: 10px;
+.model-label { color: var(--text-muted); }
+
+.btn-primary {
+  margin-top: 14px;
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: var(--radius);
+  padding: 10px 22px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
 }
 
-#prompt-input {
-    flex: 1;
-    padding: 12px;
-    border: 1px solid #ddd;
-    border-radius: 4px;
-    font-size: 1rem;
+.btn-primary:hover { opacity: 0.9; }
+
+.btn-secondary {
+  background: var(--surface2);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 22px;
+  font-size: 13px;
+  cursor: pointer;
 }
 
-button {
-    padding: 12px 24px;
-    background-color: var(--primary-color);
-    color: white;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 1rem;
-    transition: background-color 0.2s;
+/* Tooltip */
+.tooltip-wrap { position: relative; display: inline-block; }
+.tooltip-trigger { font-size: 11px; color: var(--accent); cursor: pointer; user-select: none; }
+
+.tooltip-body {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 10;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 14px;
+  font-size: 12px;
+  color: var(--text-muted);
+  width: 260px;
+  margin-top: 6px;
+  line-height: 1.6;
 }
 
-button:hover {
-    background-color: var(--primary-hover);
+/* Narrative feed */
+.feed-header { margin-bottom: 18px; }
+.feed-mission { font-size: 17px; font-weight: 600; margin-bottom: 4px; }
+.feed-model { font-size: 12px; color: var(--text-dim); }
+
+#feed { display: flex; flex-direction: column; gap: 10px; }
+
+.feed-line {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-size: 13px;
+  color: var(--text);
+  line-height: 1.5;
 }
 
-.task-item {
-    padding: 10px;
-    margin-bottom: 10px;
-    background-color: #f8f9fa;
-    border-radius: 4px;
-    cursor: pointer;
-    transition: background-color 0.2s;
+.feed-line.done { color: var(--text-dim); }
+.feed-line.done::before { content: "✓"; color: var(--green); flex-shrink: 0; }
+.feed-line.active::after { content: "▍"; animation: blink 1s step-end infinite; }
+.feed-line.error { color: var(--red); }
+.feed-line.error::before { content: "✕"; flex-shrink: 0; }
+
+@keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+
+.savings-live { font-size: 12px; color: var(--green); margin-top: 16px; }
+
+/* Task complete */
+.complete-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  margin-top: 16px;
 }
 
-.task-item:hover {
-    background-color: #e9ecef;
+.complete-card pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 13px;
+  color: var(--text);
+  line-height: 1.6;
+  font-family: var(--font);
 }
 
-.task-item.active {
-    background-color: var(--primary-color);
-    color: white;
+.btn-copy {
+  margin-top: 12px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  padding: 6px 14px;
+  font-size: 12px;
+  cursor: pointer;
 }
 
-#input-container.bottom {
-    margin-top: auto;
+/* Setup wizard */
+.wizard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
+  text-align: center;
+  gap: 18px;
+  max-width: 380px;
+  margin: 0 auto;
 }
 
-.task-card {
-    background: #fff;
-    padding: 15px;
-    margin-bottom: 10px;
-    border-radius: 8px;
-    cursor: pointer;
-    transition: all 0.2s;
+.wizard-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 1px;
 }
 
-.task-card:hover {
-    transform: translateX(5px);
-    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+.dot-green {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 6px var(--green);
 }
 
-.status-pending {
-    color: var(--text-light);
+.wizard-title { font-size: 28px; font-weight: 800; letter-spacing: -0.5px; }
+
+.wizard-stats {
+  display: flex;
+  gap: 28px;
+  padding: 14px 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  width: 100%;
+  justify-content: center;
 }
 
-.status-running {
-    color: var(--primary-color);
+.stat { display: flex; flex-direction: column; align-items: center; gap: 4px; }
+.stat-value { font-size: 18px; font-weight: 700; color: var(--green); }
+.stat-label { font-size: 10px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.5px; }
+
+.wizard-desc { font-size: 13px; color: var(--text-muted); line-height: 1.6; }
+.wizard-hint { font-size: 11px; color: var(--text-dim); }
+.wizard-error { font-size: 12px; color: var(--amber); margin-top: -6px; }
+
+/* Cloud dialog */
+.cloud-dialog {
+  background: var(--surface);
+  border: 1px solid #7c3aed;
+  border-radius: 12px;
+  padding: 22px;
+  max-width: 340px;
 }
 
-.status-completed {
-    color: var(--success-color);
+.cloud-dialog-header { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
+
+.dot-amber { width: 8px; height: 8px; border-radius: 50%; background: var(--amber); }
+
+.cloud-dialog-headline { font-size: 13px; font-weight: 600; color: var(--amber); }
+.cloud-dialog-body { font-size: 12px; color: var(--text-muted); line-height: 1.5; margin-bottom: 14px; }
+
+.cost-row {
+  background: var(--bg);
+  border-radius: 6px;
+  padding: 8px 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 14px;
 }
 
-.status-failed {
-    color: var(--error-color);
+.cost-label { font-size: 11px; color: var(--text-dim); }
+.cost-value { font-size: 14px; font-weight: 600; }
+.cloud-actions { display: flex; flex-direction: column; gap: 6px; }
+
+.btn-approve {
+  background: #7c3aed;
+  color: white;
+  border: none;
+  border-radius: var(--radius);
+  padding: 10px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  width: 100%;
 }
 
-.step-container {
-    display: block;
-    padding: 15px;
-    width: 100%;
-    max-height: calc(100vh - 300px);
-    overflow-y: auto;
-}
-
-.step-item {
-    padding: 15px;
-    background: white;
-    border-radius: 8px;
-    width: 100%;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-    margin-bottom: 10px;
-    opacity: 1;
-    transform: none;
-}
-
-.step-item .log-line:not(.result) {
-    opacity: 0.7;
-    color: #666;
-    font-size: 0.9em;
-}
-
-.step-item .log-line.result {
-    opacity: 1;
-    color: #333;
-    font-size: 1em;
-    background: #e8f5e9;
-    border-left: 4px solid #4caf50;
-    padding: 10px;
-    border-radius: 4px;
-}
-
-.step-item.show {
-    opacity: 1;
-    transform: none;
-}
-
-.log-line {
-    padding: 10px;
-    border-radius: 4px;
-    margin-bottom: 10px;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-}
-
-.log-line.think,
-.step-item pre.think {
-    background: var(--info-color-light);
-    border-left: 4px solid var(--info-color);
-}
-
-.log-line.tool,
-.step-item pre.tool {
-    background: var(--warning-color-light);
-    border-left: 4px solid var(--warning-color);
-}
-
-.log-line.result,
-.step-item pre.result {
-    background: var(--success-color-light);
-    border-left: 4px solid var(--success-color);
-}
-
-.log-line.error,
-.step-item pre.error {
-    background: var(--error-color-light);
-    border-left: 4px solid var(--error-color);
-}
-
-.log-line.info,
-.step-item pre.info {
-    background: var(--bg-color);
-    border-left: 4px solid var(--text-light);
-}
-
-/* 删除重复的样式定义 */
-
-.log-prefix {
-    font-weight: bold;
-    margin-bottom: 5px;
-    color: #666;
-}
-
-.step-item pre {
-    padding: 10px;
-    border-radius: 4px;
-    margin: 10px 0;
-    overflow-x: auto;
-    padding: 10px;
-    border-radius: 4px;
-    margin: 10px 0;
-    overflow-x: auto;
-    font-family: 'Courier New', monospace;
-    font-size: 0.9em;
-    line-height: 1.4;
-    white-space: pre-wrap;
-    color: var(--text-color);
-    background: var(--bg-color);
-
-    &.log {
-        background: var(--bg-color);
-        border-left: 4px solid var(--text-light);
-    }
-    &.think {
-        background: var(--info-color-light);
-        border-left: 4px solid var(--info-color);
-    }
-    &.tool {
-        background: var(--warning-color-light);
-        border-left: 4px solid var(--warning-color);
-    }
-    &.result {
-        background: var(--success-color-light);
-        border-left: 4px solid var(--success-color);
-    }
-}
-
-.step-item strong {
-    display: block;
-    margin-bottom: 8px;
-    color: #007bff;
-    font-size: 0.9em;
-}
-
-.step-item div {
-    color: #444;
-    line-height: 1.6;
-}
-
-.loading {
-    padding: 15px;
-    color: #666;
-    text-align: center;
-}
-
-.ping {
-    color: #ccc;
-    text-align: center;
-    margin: 5px 0;
-}
-
-.error {
-    color: #dc3545;
-    padding: 10px;
-    background: #ffe6e6;
-    border-radius: 4px;
-    margin: 10px 0;
-}
-
-.complete {
-    color: #28a745;
-    padding: 10px;
-    background: #e6ffe6;
-    border-radius: 4px;
-    margin: 10px 0;
+.btn-local {
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px;
+  font-size: 12px;
+  cursor: pointer;
+  width: 100%;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -86,6 +86,12 @@ body {
   border-top: 1px solid var(--border);
 }
 
+.stat-line {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 4px;
+}
+
 /* Mission input */
 .mission-title { font-size: 22px; font-weight: 700; margin-bottom: 16px; }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AaplaManus</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <script src="https://unpkg.com/htmx.org@2.0.4" defer></script>
+  <script src="https://unpkg.com/alpinejs@3.14.8/dist/cdn.min.js" defer></script>
+</head>
+<body>
+  {% block content %}{% endblock %}
+  <script src="/static/main.js" defer></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,39 +1,23 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OpenManus Local Version</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="container">
-        <div class="history-panel">
-            <h2>History Tasks</h2>
-            <div id="task-list" class="task-list"></div>
-        </div>
+{% extends "base.html" %}
 
-        <div class="main-panel">
-            <div id="task-container" class="task-container">
-                <div class="welcome-message">
-                    <h1>Welcome to OpenManus Local Version</h1>
-                    <p>Please enter a task prompt to start a new task</p>
-                </div>
-                <div id="log-container" class="step-container"></div>
-            </div>
+{% block content %}
+<div class="layout">
 
-            <div id="input-container" class="input-container">
-                <input
-                    type="text"
-                    id="prompt-input"
-                    placeholder="Enter task prompt..."
-                    onkeypress="if(event.keyCode === 13) createTask()"
-                >
-                <button onclick="createTask()">Create Task</button>
-            </div>
-        </div>
-    </div>
+  <div class="panel-left"
+    id="history-panel"
+    hx-get="/partials/history"
+    hx-trigger="load, refresh from:#history-panel"
+    hx-swap="innerHTML">
+    <div class="history-empty">Loading...</div>
+  </div>
 
-    <script src="/static/main.js"></script>
-</body>
-</html>
+  <div class="panel-right" id="right-panel">
+    {% if ollama_ok %}
+      {% include "partials/mission-input.html" %}
+    {% else %}
+      {% include "partials/setup-wizard.html" %}
+    {% endif %}
+  </div>
+
+</div>
+{% endblock %}

--- a/templates/partials/cloud-dialog.html
+++ b/templates/partials/cloud-dialog.html
@@ -1,0 +1,30 @@
+<div class="cloud-dialog">
+  <div class="cloud-dialog-header">
+    <div class="dot-amber"></div>
+    <div class="cloud-dialog-headline">Data will leave this device</div>
+  </div>
+
+  <div class="cloud-dialog-body">
+    Sending to {{ model }}. Your prompt and any attached files will be processed on external servers.
+  </div>
+
+  <div class="cost-row">
+    <span class="cost-label">Estimated cost</span>
+    <span class="cost-value">${{ "%.2f"|format(estimated_cost) }}</span>
+  </div>
+
+  <div class="cloud-actions">
+    <button
+      class="btn-approve"
+      hx-post="/tasks/cloud-approve"
+      hx-vals='{"task_id": "{{ task_id }}"}'
+      hx-target="#right-panel"
+      hx-swap="innerHTML">
+      Approve and send to cloud
+    </button>
+
+    <button class="btn-local" onclick="location.reload()">
+      Run locally instead
+    </button>
+  </div>
+</div>

--- a/templates/partials/history.html
+++ b/templates/partials/history.html
@@ -17,3 +17,7 @@
 {% endif %}
 
 <div class="savings-total">Saved ${{ "%.2f"|format(total_savings) }} total</div>
+<div class="stat-line">{{ tasks_completed }} tasks completed</div>
+{% if most_used_agent %}
+<div class="stat-line">Most used: {{ most_used_agent }}</div>
+{% endif %}

--- a/templates/partials/history.html
+++ b/templates/partials/history.html
@@ -1,0 +1,19 @@
+<h2>Recent Missions</h2>
+
+{% if tasks %}
+  {% for task in tasks %}
+  <div class="history-item">
+    <div class="history-prompt">{{ task.prompt[:60] }}{% if task.prompt|length > 60 %}…{% endif %}</div>
+    <div class="history-status">
+      {% if task.status == "completed" %}Done
+      {% elif task.status == "running" %}Running...
+      {% elif task.status.startswith("failed") %}Failed
+      {% else %}{{ task.status }}{% endif %}
+    </div>
+  </div>
+  {% endfor %}
+{% else %}
+  <div class="history-empty">No missions yet</div>
+{% endif %}
+
+<div class="savings-total">Saved ${{ "%.2f"|format(total_savings) }} total</div>

--- a/templates/partials/mission-input.html
+++ b/templates/partials/mission-input.html
@@ -1,0 +1,25 @@
+<div class="mission-title">Brief Manus</div>
+
+<form id="mission-form">
+  <textarea
+    id="prompt-input"
+    class="mission-input"
+    placeholder="What's the mission?"
+    rows="3"
+  ></textarea>
+
+  <div class="model-indicator">
+    Using: <span id="model-label" class="model-label">Fast Local</span>
+    <div class="tooltip-wrap" x-data="{ open: false }">
+      <span class="tooltip-trigger" @click="open = !open">[?]</span>
+      <div class="tooltip-body" x-show="open" x-cloak>
+        <strong>Fast Local</strong> — Quick answers. Runs on your device.<br>
+        <strong>Smart Local</strong> — Best for research. Still local.<br>
+        <strong>Code Expert</strong> — Specialized for code. Runs locally.<br>
+        <strong>Cloud</strong> — Sends data to external servers. Costs money.
+      </div>
+    </div>
+  </div>
+
+  <button type="submit" class="btn-primary" hx-post="/tasks">Run mission</button>
+</form>

--- a/templates/partials/mission-input.html
+++ b/templates/partials/mission-input.html
@@ -21,5 +21,5 @@
     </div>
   </div>
 
-  <button type="submit" class="btn-primary" hx-post="/tasks">Run mission</button>
+  <button type="submit" class="btn-primary">Run mission</button>
 </form>

--- a/templates/partials/setup-wizard.html
+++ b/templates/partials/setup-wizard.html
@@ -1,4 +1,46 @@
 <div class="wizard">
+  <div class="wizard-status">
+    <div class="dot-green"></div>
+    Local AI System
+  </div>
+
   <div class="wizard-title">AaplaManus</div>
-  <div class="wizard-desc">Setting up... (full wizard coming)</div>
+
+  <div class="wizard-stats">
+    <div class="stat">
+      <div class="stat-value">$0</div>
+      <div class="stat-label">API Cost</div>
+    </div>
+    <div class="stat">
+      <div class="stat-value">0</div>
+      <div class="stat-label">Data Sent Out</div>
+    </div>
+    <div class="stat">
+      <div class="stat-value" style="font-size:13px;line-height:1.2;">Your HW</div>
+      <div class="stat-label">Runs On</div>
+    </div>
+  </div>
+
+  <div class="wizard-desc">
+    To get started, you need Ollama — a free runtime that runs AI models locally.
+    One install, then you're done.
+  </div>
+
+  <a
+    href="https://ollama.com"
+    target="_blank"
+    class="btn-primary"
+    style="text-decoration:none;display:inline-block;padding:12px 32px;">
+    Download Ollama — Free
+  </a>
+
+  <div class="wizard-hint">Takes about 2 minutes. No account, no credit card.</div>
+
+  <button class="btn-secondary" onclick="location.reload()">
+    I installed it — continue
+  </button>
+
+  {% if show_error is defined and show_error %}
+  <div class="wizard-error">Still not detected. Try restarting Ollama, then click again.</div>
+  {% endif %}
 </div>

--- a/templates/partials/setup-wizard.html
+++ b/templates/partials/setup-wizard.html
@@ -1,0 +1,4 @@
+<div class="wizard">
+  <div class="wizard-title">AaplaManus</div>
+  <div class="wizard-desc">Setting up... (full wizard coming)</div>
+</div>

--- a/templates/partials/task-complete.html
+++ b/templates/partials/task-complete.html
@@ -1,0 +1,12 @@
+<div class="feed-header">
+  <div class="feed-mission">Mission complete</div>
+</div>
+
+<div class="complete-card">
+  <pre id="complete-output">{{ output }}</pre>
+  <button
+    class="btn-copy"
+    onclick="navigator.clipboard.writeText(document.getElementById('complete-output').textContent).then(() => this.textContent = 'Copied!')">
+    Copy result
+  </button>
+</div>

--- a/templates/partials/task-running.html
+++ b/templates/partials/task-running.html
@@ -1,1 +1,17 @@
-<div id="task-feed" data-task-id="{{ task_id }}"><div id="feed"></div></div>
+<div class="feed-header">
+  <div class="feed-mission">Running mission...</div>
+  <div class="feed-model">
+    Smart Local
+    <div class="tooltip-wrap" x-data="{ open: false }">
+      <span class="tooltip-trigger" @click="open = !open">[?]</span>
+      <div class="tooltip-body" x-show="open" x-cloak>
+        A powerful model running on your own hardware. Nothing sent to the internet.
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="task-feed" data-task-id="{{ task_id }}">
+  <div id="feed"></div>
+  <div class="savings-live" id="savings-live">Saved $0.00 so far</div>
+</div>

--- a/templates/partials/task-running.html
+++ b/templates/partials/task-running.html
@@ -1,0 +1,1 @@
+<div id="task-feed" data-task-id="{{ task_id }}"><div id="feed"></div></div>

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -41,8 +41,9 @@ def test_history_partial_renders(client):
     with patch.object(
         app_module._cost_service_module.cost_service,
         "get_stats",
-        return_value={"total_savings_usd": 0.0},
+        return_value={"alltime_saved_usd": 1.23},
     ):
         response = client.get("/partials/history")
     assert response.status_code == 200
     assert "No missions" in response.text or "Saved $" in response.text
+    assert "Saved $1.23 total" in response.text

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,48 @@
+# tests/test_templates.py
+import importlib.util
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+app_path = Path(__file__).parent.parent / "app.py"
+spec_obj = importlib.util.spec_from_file_location("app_module", app_path)
+app_module = importlib.util.module_from_spec(spec_obj)
+spec_obj.loader.exec_module(app_module)
+
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)
+
+
+def test_setup_wizard_contains_value_props(client):
+    with patch.object(app_module, "_check_ollama", new=AsyncMock(return_value=False)):
+        response = client.get("/")
+    assert response.status_code == 200
+    assert "$0" in response.text
+    assert "Data Sent Out" in response.text
+    assert "Your HW" in response.text
+
+
+def test_cloud_dialog_privacy_language(client):
+    long_prompt = "research " + "word " * 82
+    create_resp = client.post("/tasks", json={"prompt": long_prompt})
+    task_id = create_resp.json()["task_id"]
+
+    response = client.get(f"/partials/cloud-dialog?task_id={task_id}&cost=0.04&model=gpt-4o")
+    assert response.status_code == 200
+    assert "Data will leave this device" in response.text
+    assert "Approve and send to cloud" in response.text
+
+
+def test_history_partial_renders(client):
+    with patch.object(
+        app_module._cost_service_module.cost_service,
+        "get_stats",
+        return_value={"total_savings_usd": 0.0},
+    ):
+        response = client.get("/partials/history")
+    assert response.status_code == 200
+    assert "No missions" in response.text or "Saved $" in response.text

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -1,0 +1,59 @@
+# tests/test_ui_routes.py
+import importlib.util
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+app_path = Path(__file__).parent.parent / "app.py"
+spec_obj = importlib.util.spec_from_file_location("app_module", app_path)
+app_module = importlib.util.module_from_spec(spec_obj)
+spec_obj.loader.exec_module(app_module)
+
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)
+
+
+def test_home_returns_htmx_form(client):
+    with patch.object(app_module, "_check_ollama", new=AsyncMock(return_value=True)):
+        response = client.get("/")
+    assert response.status_code == 200
+    assert 'hx-post="/tasks"' in response.text
+
+
+def test_ollama_health_ok(client):
+    with patch.object(app_module, "_check_ollama", new=AsyncMock(return_value=True)):
+        response = client.get("/health/ollama")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_ollama_health_unavailable(client):
+    with patch.object(app_module, "_check_ollama", new=AsyncMock(return_value=False)):
+        response = client.get("/health/ollama")
+    assert response.status_code == 503
+    assert response.json()["status"] == "unavailable"
+
+
+def test_complex_task_returns_approval_info(client):
+    # > 80 words triggers is_complex in classify()
+    long_prompt = "research " + "word " * 82
+    response = client.post("/tasks", json={"prompt": long_prompt})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["requires_approval"] is True
+    assert "estimated_cost" in data
+    assert "task_id" in data
+
+
+def test_cloud_approve_starts_task(client):
+    long_prompt = "research " + "word " * 82
+    create_resp = client.post("/tasks", json={"prompt": long_prompt})
+    task_id = create_resp.json()["task_id"]
+
+    response = client.post("/tasks/cloud-approve", json={"task_id": task_id})
+    assert response.status_code == 200
+    assert task_id in response.text

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -58,3 +58,23 @@ def test_cloud_approve_starts_task(client):
     response = client.post("/tasks/cloud-approve", json={"task_id": task_id})
     assert response.status_code == 200
     assert task_id in response.text
+
+
+def test_history_partial_includes_task_count(client):
+    with patch.object(
+        app_module._cost_service_module.cost_service,
+        "get_stats",
+        return_value={"alltime_saved_usd": 0.0, "tasks_completed": 5, "most_used_agent": None},
+    ):
+        response = client.get("/partials/history")
+    assert "5 tasks completed" in response.text
+
+
+def test_history_partial_includes_most_used_agent(client):
+    with patch.object(
+        app_module._cost_service_module.cost_service,
+        "get_stats",
+        return_value={"alltime_saved_usd": 0.0, "tasks_completed": 1, "most_used_agent": "research_agent"},
+    ):
+        response = client.get("/partials/history")
+    assert "Most used: research_agent" in response.text

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -21,7 +21,8 @@ def test_home_returns_htmx_form(client):
     with patch.object(app_module, "_check_ollama", new=AsyncMock(return_value=True)):
         response = client.get("/")
     assert response.status_code == 200
-    assert 'hx-post="/tasks"' in response.text
+    assert 'hx-get="/partials/history"' in response.text
+    assert 'id="mission-form"' in response.text
 
 
 def test_ollama_health_ok(client):

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -78,3 +78,14 @@ def test_history_partial_includes_most_used_agent(client):
     ):
         response = client.get("/partials/history")
     assert "Most used: research_agent" in response.text
+
+
+def test_dashboard_stats_session_savings_defaults_to_zero(client):
+    with patch.object(
+        app_module._cost_service_module.cost_service,
+        "get_stats",
+        return_value={"session_saved_usd": 0.0, "alltime_saved_usd": 0.0, "alltime_tokens": 0, "tasks_completed": 0, "most_used_agent": None},
+    ):
+        response = client.get("/dashboard/stats?session_id=nonexistent-id")
+    assert response.status_code == 200
+    assert response.json()["session_saved_usd"] == 0.0


### PR DESCRIPTION
## Summary

**Plan 3 — HTMX two-panel UI redesign:**
- Replace inherited OpenManus HTML with dark-theme two-panel dashboard (left = history, right = mission input / task running / completion)
- Server-side Ollama check on GET / — setup wizard when unavailable, full dashboard when ready
- New backend endpoints: /health/ollama, /partials/history, /partials/task-running, /partials/task-complete, /partials/cloud-dialog, /classify, /tasks/cloud-approve
- SSE narrative feed using named addEventListener per event type (think/tool/act/run/complete)
- Privacy-first cloud approval dialog with cost estimate before routing complex tasks to cloud

**Plan 4 — Real-time cost dashboard:**
- History sidebar now shows tasks_completed and most_used_agent from CostService alongside savings total
- Live savings counter in task-running screen polls /dashboard/stats?session_id=taskId every 2s
- Full SSE cleanup on complete, error, and mid-task navigation (_cleanupSSE pattern closes both interval and EventSource)

## Test Plan

- [ ] 53/53 tests pass: `pytest tests/ -v`
- [ ] Start server: `python app.py` (not uvicorn app:app — broken due to app/ package collision)
- [ ] Confirm setup wizard when Ollama is down, dashboard when up
- [ ] Submit short prompt, watch SSE narrative feed and savings counter update live
- [ ] Submit prompt >80 words, verify cloud approval dialog
- [ ] History sidebar shows tasks_completed and most_used_agent after a task completes
- [ ] Navigate away mid-task, confirm no orphaned SSE connections

## Notes

Three critical bugs fixed post-Plan 3 code review: SSE onmessage silent drop (named events), double task submission (hx-post + JS fetch), savings key mismatch (total_savings_usd vs alltime_saved_usd).

One known pre-existing issue: tasks_completed in CostService counts token_log rows (one per agent call), not distinct tasks. Multi-agent tasks inflate the count. Fix belongs in cost_service.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)